### PR TITLE
Merge RootEntry/fix-rust-edition into main

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/mold", "-C", "target-cpu=native"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold", "-C", "target-cpu=native"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,20 @@
+name: Rust Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run project tests
+      run: cargo test --all --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: rui314/setup-mold@v1
     - name: Build
       run: cargo build --verbose
     - name: Run project tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ default-members = ["compiler/driver"]
 [workspace.package]
 authors = ["AndreRojasMartinsson"]
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [workspace.dependencies]
 interner = {path = "compiler/interner"}

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -1,5 +1,5 @@
 use gxhash::{HashMap, HashMapExt};
-use interner::{Atom, lookup};
+use interner::{lookup, Atom};
 use lexer::operator::{AssignOp, BinaryOp, PostfixOp, PrefixOp};
 use node::Node;
 use std::{cell::RefCell, cmp::Ordering, fs::File, io::Write, primitive};
@@ -9,8 +9,8 @@ use ast::{
     LiteralValue, Parameter, Program, ProgramItem, Ty, Type as AstType,
 };
 use ir_builder::{
-    Argument, Block, Cmp, Data, DataItem, Function, GC_NOOP, ImutStr, Instruction, Linkage, Module,
-    Prefix, Primitive, Statement, StructPool, Type, Value,
+    Argument, Block, Cmp, Data, DataItem, Function, ImutStr, Instruction, Linkage, Module, Prefix,
+    Primitive, Statement, StructPool, Type, Value, GC_NOOP,
 };
 
 mod builder;
@@ -147,7 +147,8 @@ impl CodeGen {
         }
         // file.flush().map_err(|_| "Failed to flush file.")?;
 
-        Ok(module_ref.borrow().to_string())
+        let ir = module_ref.borrow().to_string();
+        Ok(ir)
     }
 
     fn tmp_name_with_debug_assertions(&self, name: &ImutStr, minify: bool) -> String {


### PR DESCRIPTION
Adds the rust.yml workflow to github to run project tests
on push and pull-request in the main branch.

Changes rust edition from 2024 to 2021 to fix rust.yml
failing due to unstable rust edition 2024.